### PR TITLE
Make Build Scripts Less Brittle

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -8,13 +8,20 @@ IF NOT [%2]==[] (set TAG=%2)
 SET TAG=%TAG:tags/=%
 
 curl -o nuget.exe https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -k
+if %errorlevel% neq 0 exit /b %errorlevel%
 
 .\nuget.exe restore .\src\ViewModels.ApplicationState.Tests\ViewModels.ApplicationState.Tests.csproj -PackagesDirectory .\src\packages -Verbosity detailed
+if %errorlevel% neq 0 exit /b %errorlevel%
 .\nuget.exe restore .\src\ViewModels.ApplicationState\ViewModels.ApplicationState.csproj -PackagesDirectory .\src\packages -Verbosity detailed
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+if %errorlevel% neq 0 exit /b %errorlevel%
 
 dotnet build .\src\ViewModels.ApplicationState\ViewModels.ApplicationState.csproj -p:Version=%VERSION% -c Release
+if %errorlevel% neq 0 exit /b %errorlevel%
 
 dotnet test .\src\ViewModels.ApplicationState.Tests\ViewModels.ApplicationState.Tests.csproj
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 dotnet pack .\src\ViewModels.ApplicationState\ViewModels.ApplicationState.csproj -o ..\..\dist -p:Version="%VERSION%" -p:PackageVersion="%VERSION%" -p:Tag="%TAG%" -c Release
+exit /b %errorlevel%

--- a/build.cmd
+++ b/build.cmd
@@ -12,9 +12,8 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 
 .\nuget.exe restore .\src\ViewModels.ApplicationState.Tests\ViewModels.ApplicationState.Tests.csproj -PackagesDirectory .\src\packages -Verbosity detailed
 if %errorlevel% neq 0 exit /b %errorlevel%
-.\nuget.exe restore .\src\ViewModels.ApplicationState\ViewModels.ApplicationState.csproj -PackagesDirectory .\src\packages -Verbosity detailed
-if %errorlevel% neq 0 exit /b %errorlevel%
 
+.\nuget.exe restore .\src\ViewModels.ApplicationState\ViewModels.ApplicationState.csproj -PackagesDirectory .\src\packages -Verbosity detailed
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 dotnet build .\src\ViewModels.ApplicationState\ViewModels.ApplicationState.csproj -p:Version=%VERSION% -c Release

--- a/src/ViewModels.ApplicationState.Tests/ViewModels.ApplicationState.Tests.csproj
+++ b/src/ViewModels.ApplicationState.Tests/ViewModels.ApplicationState.Tests.csproj
@@ -44,8 +44,8 @@
     <DocumentationFile>bin\Release\CR.ViewModels.Core.Tests.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CR.ViewModels.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\CR.ViewModels.Core.1.0.0\lib\netstandard2.0\CR.ViewModels.Core.dll</HintPath>
+    <Reference Include="CR.ViewModels.Core, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\CR.ViewModels.Core.1.0.1\lib\netstandard2.0\CR.ViewModels.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.CodeCoverage.Shim, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/ViewModels.ApplicationState.Tests/packages.config
+++ b/src/ViewModels.ApplicationState.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CR.CodeStyle.CSharp.Full" version="1.0.1" targetFramework="net471" developmentDependency="true" />
-  <package id="CR.ViewModels.Core" version="1.0.0" targetFramework="net471" />
+  <package id="CR.ViewModels.Core" version="1.0.1" targetFramework="net471" />
   <package id="Microsoft.CodeCoverage" version="1.0.3" targetFramework="net471" />
   <package id="Microsoft.NET.Test.Sdk" version="15.7.2" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net471" />

--- a/src/ViewModels.ApplicationState/ViewModels.ApplicationState.csproj
+++ b/src/ViewModels.ApplicationState/ViewModels.ApplicationState.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="CR.CodeStyle.CSharp.Full" Version="[1.0.1,2.0.0-0)">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-	<PackageReference Include="CR.ViewModels.Core" Version="[1.0.0,2.0.0-a)" />
+	<PackageReference Include="CR.ViewModels.Core" Version="[1.0.1,2.0.0-a)" />
   </ItemGroup>
   <ItemGroup>
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.1.0-beta006\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />


### PR DESCRIPTION
- Fixed build.sh
- Ignore self signed https certificate error with curl
- On any operation returning a non-zero error level, fail build.cmd immediately with the same error level.
- Use ViewModels.Core 1.0.1; Celsius was resolving it as a .Net Framework only package for some reason.